### PR TITLE
Improving benchmark in particular with respect to #16

### DIFF
--- a/benchmarks/benchmark_script.py
+++ b/benchmarks/benchmark_script.py
@@ -1,3 +1,7 @@
+# This code is based on the code
+# from ann-benchmark repository 
+# created by Erik Bernhardsson 
+# https://github.com/erikbern/ann-benchmarks
 import gzip
 import numpy
 import time
@@ -91,7 +95,7 @@ class N2(BaseANN):
         self._ef_construction = ef_construction
         self._n_threads = n_threads
         self._ef_search = ef_search
-        self._index_name = os.path.join(INDEX_DIR, "n2_%s_M%d_efCon%d_n_thread%s" % (args.dataset, m, ef_construction, n_threads))
+        self._index_name = os.path.join(INDEX_DIR, "n2_%s_M%d_efCon%d_n_thread%s_data_size%d" % (args.dataset, m, ef_construction, n_threads, max(args.data_size, 0)))
         self.name = "N2_M%d_efCon%d_n_thread%s_efSearch%d" % (m, ef_construction, n_threads, ef_search)
         self._metric = metric
 
@@ -122,25 +126,91 @@ class N2(BaseANN):
     def __str__(self):
          return self.name
 
-def get_fn(base, args):
-    fn = os.path.join(base, args.dataset)
+class NmslibReuseIndex(BaseANN):
+    def __init__( self, metric, method_name, index_param, save_index,query_param):
+        self._nmslib_metric = {
+            'angular': 'cosinesimil',
+            'euclidean': 'l2'}[metric]
+        self._method_name = method_name
+        self._save_index = save_index
+        self._index_param = index_param
+        self._query_param = query_param
+        self.name = 'Nmslib(method_name=%s, index_param=%s, query_param=%s)' % (
+            method_name, index_param, query_param)
+        self._index_name = os.path.join(
+            INDEX_DIR, "youtube_nmslib_%s_%s_%s_data_size_%d" %
+            (self._method_name, metric, '_'.join(
+                self._index_param), max(args.data_size, 0)))
 
-    if args.limit != -1:
-        fn += '-%d' % args.limit
-    if os.path.exists(fn + '.gz'):
-        fn += '.gz'
-    else:
-        fn += '.txt'
+        d = os.path.dirname(self._index_name)
+        if not os.path.exists(d):
+            os.makedirs(d)
 
-    d = os.path.dirname(fn)
-    if not os.path.exists(d):
-        os.makedirs(d)
+    def fit(self, X):
+        import nmslib
+        self._index = nmslib.init(
+            self._nmslib_metric,
+            [],
+            self._method_name,
+            nmslib.DataType.DENSE_VECTOR,
+            nmslib.DistType.FLOAT)
 
-    return fn
+        for i, x in enumerate(X):
+            nmslib.addDataPoint(self._index, i, x.tolist())
+
+        if os.path.exists(self._index_name):
+            logging.debug("Loading index from file")
+            nmslib.loadIndex(self._index, self._index_name)
+        else:
+            logging.debug("Create Index")
+            nmslib.createIndex(self._index, self._index_param)
+            if self._save_index:
+                nmslib.saveIndex(self._index, self._index_name)
+
+        nmslib.setQueryTimeParams(self._index, self._query_param)
+
+    def query(self, v, n):
+        import nmslib
+        return nmslib.knnQuery(self._index, n, v.tolist())
+
+    def freeIndex(self):
+        import nmslib
+        nmslib.freeIndex(self._index)
+
+
+class Annoy(BaseANN):
+    def __init__(self, metric, n_trees, search_k):
+        self._n_trees = n_trees
+        self._search_k = search_k
+        self._metric = metric
+        self._index_name = os.path.join(
+            INDEX_DIR, "youtube_annoy_%s_tree%d_data_size_%d" %
+            (metric, n_trees, max(args.data_size, 0)))
+        self.name = 'Annoy(n_trees=%d, search_k=%d)' % (n_trees, search_k)
+
+        d = os.path.dirname(self._index_name)
+        if not os.path.exists(d):
+            os.makedirs(d)
+
+    def fit(self, X):
+        import annoy
+        self._annoy = annoy.AnnoyIndex(f=X.shape[1], metric=self._metric)
+        if os.path.exists(self._index_name):
+            logging.debug("Loading index from file")
+            self._annoy.load(self._index_name)
+        else:
+            logging.debug("Index file not exist start fitting!!")
+            for i, x in enumerate(X):
+                self._annoy.add_item(i, x.tolist())
+            self._annoy.build(self._n_trees)
+            self._annoy.save(self._index_name)
+
+    def query(self, v, n):
+        return self._annoy.get_nns_by_vector(v.tolist(), n, self._search_k)
 
 def run_algo(args, library, algo, results_fn):
     pool = multiprocessing.Pool()
-    X_train, X_test = get_dataset(args.dataset, args.limit)
+    X_train, X_test = get_dataset(which=args.dataset, data_size=args.data_size, test_size=args.test_size, random_state = args.random_state)
     pool.close()
     pool.join()
 
@@ -150,7 +220,7 @@ def run_algo(args, library, algo, results_fn):
     n2_logger.info('Built index in {0}'.format(build_time))
     best_search_time = float('inf')
     best_precision = 0.0 # should be deterministic but paranoid
-    try_count = 3
+    try_count = args.try_count
     for i in xrange(try_count): # Do multiple times to warm up page cache, use fastest
         results = []
         search_time = 0.0
@@ -181,8 +251,8 @@ def run_algo(args, library, algo, results_fn):
     f.close()
     n2_logger.info('Summary: {0}'.format('\t'.join(map(str, output))))
 
-def get_dataset(which='glove', limit=-1, random_state = 3, test_size = 10000):
-    cache = 'queries/%s-%d-%d-%d.npz' % (which, test_size, limit, random_state)
+def get_dataset(which='glove', data_size=-1, test_size = 10000, random_state = 3):
+    cache = 'queries/%s-%d-%d-%d.npz' % (which, max(args.data_size, 0), test_size, random_state)
     if os.path.exists(cache):
         v = numpy.load(cache)
         X_train = v['train']
@@ -199,7 +269,7 @@ def get_dataset(which='glove', limit=-1, random_state = 3, test_size = 10000):
     for i, line in enumerate(f):
         v = [float(x) for x in line.strip().split()]
         X.append(v)
-        if limit != -1 and len(X) == limit:
+        if data_size != -1 and len(X) == data_size:
             break
 
     X = numpy.vstack(X)
@@ -218,7 +288,7 @@ def get_queries(args):
     n2_logger.info('computing queries with correct results...')
 
     bf = BruteForceBLAS(args.distance)
-    X_train, X_test = get_dataset(which=args.dataset, limit=args.limit)
+    X_train, X_test = get_dataset(which=args.dataset, data_size=args.data_size, test_size=args.test_size, random_state=args.random_state)
 
     # Prepare queries
     bf.fit(X_train)
@@ -235,8 +305,12 @@ def get_queries(args):
 def get_fn(base, args):
     fn = os.path.join(base, args.dataset)
 
-    if args.limit != -1:
-        fn += '-%d' % args.limit
+    if args.data_size != -1:
+        fn += '-%d' % args.data_size
+    if args.test_size != -1:
+        fn += '-%d' % args.test_size
+    fn += '-%d' % args.random_state
+
     if os.path.exists(fn + '.gz'):
         fn += '.gz'
     else:
@@ -272,16 +346,19 @@ if __name__ == '__main__':
     global GT_SIZE
     parser = argparse.ArgumentParser()
     parser.add_argument('--distance', help='Distance metric', default='angular')
+    parser.add_argument('--try_count', help='Number of test attempts', type=int, default=3)
     parser.add_argument('--dataset', help='Which dataset',  default='glove')
-    parser.add_argument('--limit', help='Limit', type=int, default=-1)
-    parser.add_argument('--ef_con', help='ef_con', type=int, default=100)
-    parser.add_argument('--ef_search', help='ef_search', type=int, default=800)
-    parser.add_argument('--M', help='M', type=int, default=10)
+    parser.add_argument('--data_size', help='Maximum # of data points', type=int, default=-1)
+    parser.add_argument('--test_size', help='Maximum # of data queries', type=int, default=10000)
     parser.add_argument('--n_threads', help='Number of threads', type=int, default=10)
+    parser.add_argument('--random_state', help='Random seed', type=int, default=3)
+    parser.add_argument('--algo', help='Algorithm', type=str)
     args = parser.parse_args()
 
     if not os.path.exists(DATA_DIR):
         os.makedirs(DATA_DIR)
+
+    numpy.random.seed(args.random_state)
 
     if args.dataset == 'glove':
         GT_SIZE = 10
@@ -296,7 +373,7 @@ if __name__ == '__main__':
 
     if args.dataset == 'glove' and not os.path.exists(GLOVE_DIR):
         download_file("https://s3-us-west-1.amazonaws.com/annoy-vectors/glove.twitter.27B.100d.txt.gz", "datasets")
-        with gzip.open('datasets/glove.twitter.27B.100d.txt.gz', 'rb') as f_in, open('datasets/glove.twitter.27B.100d.txt', 'w') as f_out:
+        with gzip.open('datasets/glove.twitter.27B.100d.txt.gz', 'rb') as f_in, open('datasets/glove.twitter.27B.100d.txt', 'wb') as f_out:
             shutil.copyfileobj(f_in, f_out)
         subprocess.call("cut -d \" \" -f 2- datasets/glove.twitter.27B.100d.txt > datasets/glove.txt", shell=True)
  
@@ -322,11 +399,47 @@ if __name__ == '__main__':
 
     logging.info('got {0} queries'.format(len(queries)))
 
-    configs = [N2(args.M, args.ef_con, args.n_threads, args.ef_search, args.distance)]
+    algos = {
+        'annoy': [ Annoy('angular', n_trees, search_k)
+                  for n_trees in [10, 50, 100]
+                  for search_k in [ 7, 3000, 50000, 200000, 500000]
+               ], 
+        'n2': [ N2(M, ef_con, args.n_threads, ef_search, 'angular') 
+               for M, ef_con in [ (12, 100)] 
+               for ef_search in [1, 10, 25, 50, 100, 250, 500, 750, 1000, 1500, 2500, 5000, 10000, 100000]
+            ], 
+        'nmslib': []}
+
+    MsPostsEfs = [
+        ({'M': 12,
+          'post': 0,
+          'indexThreadQty': args.n_threads,
+          'delaunay_type': 2,
+          'efConstruction': 100,
+          },
+         [1, 10, 25, 50, 100, 250, 500, 750, 1000, 1500, 2000, 2500],
+         ),
+    ]
+
+    for oneCase in MsPostsEfs:
+        for ef in oneCase[1]:
+            params = ['%s=%s' % (k, str(v)) for k, v in oneCase[0].items()]
+            algos['nmslib'].append(
+                NmslibReuseIndex( 'angular', 'hnsw', params, True, ['ef=%d' % ef]))
 
     algos_flat = []
-    for c in configs:
-        algos_flat.append(('n2', c))
+
+    if args.algo:
+        print('running only: %s' % str(args.algo))
+        algos = {args.algo: algos[args.algo]}
+
+    for library in algos.keys():
+        for algo in algos[library]:
+            algos_flat.append((library, algo))
+
+    random.shuffle(algos_flat)
+    logging.debug('order: %s' % str([a.name for l, a in algos_flat]))
+
     for library, algo in algos_flat:
         logging.info(algo.name)
         # Spawn a subprocess to force the memory to be reclaimed at the end


### PR DESCRIPTION
I am merging two benchmarks. More specifically:

1) I fix parameter settings for NMSLIB
2) Instead of a single limit parameter I make two separate ones: test_size and test_data
3) I try to consistently include all the parameters into the names of caches and indices.
4) I correctly attribute the script as based on ann_benchmarks code. It also seems that SIMD distance computation is based on NMSLIB code, but no attribution was given in the code.

**Unfortunately** Annoy fails for youtube with a weird error:
```
INFO:n2_benchmark:(998000, 128) (2000, 128)
INFO:n2_benchmark:Built index in 0.06020975112915039
terminate called after throwing an instance of 'std::length_error'
  what():  vector::_M_range_insert
```

Sorry, I have no time to look into this. I hope you can find the problem.

I ran benchmarks on my machine. For youtube I had to limit the size of the data set to 5M data points, but I don't think it makes a big difference. While it takes 25-30% shorter time to build the index, I see virtually no difference in query times. From some engineering perspective, n2 is certainly better (e.g., it has a clearer implementation and is lightweight). However, it doesn't seem to be better in terms of query times. Don't forget that you cannot show people a single data point (as it's done on your main page). You have to show complete recall/efficiency curves.

Thanks!

[sift-5000000-2000-3.pdf](https://github.com/kakao/n2/files/1545254/sift-5000000-2000-3.pdf)
[youtube-5000000-2000-3.pdf](https://github.com/kakao/n2/files/1545255/youtube-5000000-2000-3.pdf)
[glove-5000000-2000-3.pdf](https://github.com/kakao/n2/files/1545256/glove-5000000-2000-3.pdf)


