### PR TITLE
Treat "euclidean" as an alias of "L2".

### DIFF
--- a/docs/Cpp_API.rst
+++ b/docs/Cpp_API.rst
@@ -35,7 +35,7 @@ default value when the metric has the default value.**
 
    -  ``dim`` (int): dimension of vectors
    -  ``metric`` (std::string): an optional parameter for choosing a
-      metric of distance. (‘L2’\|‘angular’). A default metric is
+      metric of distance. (‘L2’\|'euclidean'\|‘angular’). A default metric is
       ‘angular’.
 
 -  ``void n2::HnswIndex.AddData(const std::vector<float>& data)``: adds

--- a/docs/Go_API.rst
+++ b/docs/Go_API.rst
@@ -41,7 +41,7 @@ default value when the metric has the default value.**
 
    -  ``dim`` (int): dimension of vectors
    -  ``metric`` (string): an optional parameter for choosing a metric
-      of distance. (‘L2’\|‘angular’)
+      of distance. (‘L2’\|'euclidean'\|‘angular’)
 
 -  ``index.AddData(v)``: adds vector ``v``
 

--- a/docs/Python_API.rst
+++ b/docs/Python_API.rst
@@ -7,7 +7,7 @@ Python code example
     import random
 
     f = 40
-    t = HnswIndex(f) # HnswIndex(f, "L2 or angular") 
+    t = HnswIndex(f) # HnswIndex(f, "L2, euclidean, or angular") 
     for i in xrange(1000):
         v = [random.gauss(0, 1) for z in xrange(f)]
         t.add_data(v)
@@ -29,7 +29,7 @@ default value when the metric has the default value.**
 
    -  ``dim`` (int): dimension of vectors
    -  ``metric`` (string): an optional parameter for choosing a metric
-      of distance. (‘L2’\|‘angular’)
+      of distance. (‘L2’\|'euclidean'\|‘angular’)
 
 -  ``index.add_data(v)``: adds vector ``v``
 

--- a/include/n2/hnsw.h
+++ b/include/n2/hnsw.h
@@ -63,11 +63,11 @@ public:
     Hnsw(int dim, std::string metric = "angular");
     Hnsw(const Hnsw& other);
     Hnsw(Hnsw& other);
-    Hnsw(Hnsw&& other);
+    Hnsw(Hnsw&& other) noexcept;
     ~Hnsw();
 
     Hnsw& operator=(const Hnsw& other);
-    Hnsw& operator=(Hnsw&& other);
+    Hnsw& operator=(Hnsw&& other) noexcept;
     void SetConfigs(const std::vector<std::pair<std::string, std::string> >& configs);
 
     bool SaveModel(const std::string& fname) const;

--- a/src/hnsw.cc
+++ b/src/hnsw.cc
@@ -70,7 +70,7 @@ Hnsw::Hnsw(int dim, string metric) : data_dim_(dim) {
     if (logger_ == nullptr) {
         logger_ = spdlog::stdout_logger_mt("n2");
     }
-    if(metric == "L2") {
+    if (metric == "L2" || metric =="euclidean") {
         metric_ = DistanceKind::L2;
         dist_cls_ = new L2Distance();
     } else if (metric == "angular") {

--- a/src/hnsw.cc
+++ b/src/hnsw.cc
@@ -730,8 +730,8 @@ void Hnsw::SearchById_(int cur_node_id, float cur_dist, const float* qraw, size_
         result.push_back(pair<int, float>(res_t[i].second, res_t[i].first));
     if (ensure_k_ && need_sort) {
         _mm_prefetch(&result[0], _MM_HINT_T0);
-        sort(result.begin(), result.end(), [](const pair<int, float>& i, const pair<int, float>& j) {
-                return i.second<j.second; });
+        sort(result.begin(), result.end(), [](const pair<int, float>& i, const pair<int, float>& j) -> bool {
+                return i.second < j.second; });
     }
 }
 

--- a/src/hnsw.cc
+++ b/src/hnsw.cc
@@ -115,7 +115,7 @@ Hnsw::Hnsw(Hnsw& other) {
     }
 }
 
-Hnsw::Hnsw(Hnsw&& other) {
+Hnsw::Hnsw(Hnsw&& other) noexcept {
     logger_= spdlog::get("n2");
     if (logger_ == nullptr) {
         logger_ = spdlog::stdout_logger_mt("n2");
@@ -163,7 +163,7 @@ Hnsw& Hnsw::operator=(const Hnsw& other) {
     return *this;
 }
 
-Hnsw& Hnsw::operator=(Hnsw&& other) {
+Hnsw& Hnsw::operator=(Hnsw&& other) noexcept {
     logger_= spdlog::get("n2");
     if (logger_ == nullptr) {
         logger_ = spdlog::stdout_logger_mt("n2");

--- a/src/hnsw_node.cc
+++ b/src/hnsw_node.cc
@@ -35,7 +35,7 @@ void HnswNode::CopyHigherLevelLinksToOptIndex(char* mem_offset, long long memory
 
 void HnswNode::CopyDataAndLevel0LinksToOptIndex(char* mem_offset, int higher_level_offset, int M0) const {
     char* mem_data = mem_offset;
-    *((int*)(mem_data)) = (int)higher_level_offset;
+    *((int*)(mem_data)) = higher_level_offset;
     mem_data += sizeof(int);
     CopyLinksToOptIndex(mem_data, 0);
     mem_data += (sizeof(int) + sizeof(int)*M0);

--- a/src/mmap.cc
+++ b/src/mmap.cc
@@ -64,7 +64,7 @@ size_t Mmap::QueryFileSize() const {
     if (fstat(file_handle_, &sbuf) == -1) {
         return 0;
     } else {
-        return sbuf.st_size;
+        return (size_t)sbuf.st_size;
     }
 }
 


### PR DESCRIPTION
Due to this inconsistency (compared to other NNS libraries) the
benchmark scripts all do a conditional swap from "euclidean" to
"L2" which seems extremely unnecessary and confusing.

Thanks for your contribution :)
Before you submit this pull request, please ensure it is against the dev branch and not master. 

- [ O ] ensure branch where you submitting, it should be `dev`.
- [ O ] check your coding convention.
  - 4 spaces for indentation
  - [pep8](https://www.python.org/dev/peps/pep-0008/) for Python
  
_remove above message before submitting your pull request._
