### PR TITLE
 Installing cython manually does not needed before setup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - git submodule update --init --recursive
 
 script:
-  - "pip install nose cython"
+  - "pip install nose"
   - "python setup.py install"
   - "make test_all"
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ import glob
 import platform
 import subprocess
 
-from Cython.Build import cythonize
 from setuptools import Extension, setup
 
 NAME = 'n2'
@@ -73,14 +72,13 @@ def define_extensions(**kwargs):
     include_dirs = ['./include/', './third_party/spdlog/include/', './third_party/eigen']
     include_dirs.extend(['third_party/boost/' + b + '/include/' for b in boost_dirs])
 
-    client_ext = Extension(name='n2',
-                           sources=sources,
-                           extra_compile_args=extra_compile_args,
-                           libraries=libraries,
-                           extra_link_args=extra_link_args,
-                           include_dirs=include_dirs,
-                           language="c++",)
-    return cythonize(client_ext)
+    return Extension(name='n2',
+                     sources=sources,
+                     extra_compile_args=extra_compile_args,
+                     libraries=libraries,
+                     extra_link_args=extra_link_args,
+                     include_dirs=include_dirs,
+                     language="c++",)
 
 
 setup(
@@ -91,8 +89,12 @@ setup(
     author='Kakao.corp',
     author_email='recotech.kakao@gmail.com',
     license='Apache License 2.0',
-    install_requires=[
+    setup_requires=[
+        "setuptools>=18",
         "cython",
+    ],
+    install_requires=[
+        "cython"
     ],
     classifiers=[
         'Programming Language :: Python',
@@ -102,5 +104,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'],
 
     keywords='Approximate Nearest Neighbor',
-    ext_modules=define_extensions(),
+    ext_modules=[
+        define_extensions(),
+    ]
 )


### PR DESCRIPTION
[The installation guide](https://github.com/kakao/n2/blob/dev/INSTALL.rst#python) said
"This will also install cython dependency"

But when I tried to install it the error occurred.

```
File "/private/var/folders/rq/ykn_px1d03jbhwk_pnyvm4dw0000gn/T/pip-install-8k0tr9et/n2/setup.py", line 19, in <module>
        from Cython.Build import cythonize
    ModuleNotFoundError: No module named 'Cython'
```

It is because of cython dependency in `setup.py`. It means installing cython manually is needed  before installing n2.

According to this [link](https://stackoverflow.com/questions/37471313/setup-requires-with-cython/38057196#38057196) it can avoid installing cython manually before setup. Then the import error does not occur anymore.

Actually I have not finished installation yet because of some C++ build issues. It is hard to resolve it. I cannot test it works well now. This is just an idea to improve your project. Please check carefully this PR does not have any problem.

Thank you.